### PR TITLE
chore: update

### DIFF
--- a/index.json
+++ b/index.json
@@ -14,6 +14,7 @@
   "koishi-plugin-transformers",
   "koishi-plugin-systools",
   "koishi-plugin-systools-lts",
+  "koishi-plugin-lovemilk-telemetry",
   "koishi-plugin-dispose",
   "koishi-plugin-neverlose"
 ]

--- a/index.json
+++ b/index.json
@@ -3,5 +3,17 @@
   "koishi-plugin-boom2",
   "koishi-plugin-uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu",
   "koishi-plugin-dispose-root",
+  "koishi-plugin-material-theme-undefined",
+  "koishi-plugin-k2345-security",
+  "koishi-plugin-koishi-2345",
+  "koishi-plugin-puzzle",
+  "@kuroshio/koishi-plugin-genshin",
+  "koishi-plugin-triple-sos",
+  "koishi-plugin-chatgpt-api",
+  "koishi-plugin-adapter-wechaty",
+  "koishi-plugin-transformers",
+  "koishi-plugin-systools",
+  "koishi-plugin-systools-lts",
+  "koishi-plugin-dispose",
   "koishi-plugin-neverlose"
 ]


### PR DESCRIPTION
boom: bad Node API (`process.exit()`)
boom2: bad Node API (`process.exit()`)
k2345-security: disable control of Koishi, bad monkey patch
koishi-2345: affect WebUI interface (annoying floatings), bad monkey patch (Context.prototype hack)
material-theme-undefined: affect WebUI interface (bad styles, `display: none`)
puzzle: unsafe FFI (Rust WASM binding)
@kuroshio/genshin: depend on pptr(unsafe FFI), oicq (why), lodash(should use cosmokit if possible), redis(we have assets/database service)
triple-sos: using axios(use ctx.http instead) & pptr(unsafe FFI)
chatgpt-api: using eval (string literials, but why are you using webpack though)
adapter-wechaty: koishi thirdeye(unsupported decorators), wechaty (unsafe FFI)
transformers: unsafe gpu (transformers.js)
dispose: bad peerDeps on a deprecated official plugin (`@koishijs/plugin-adapter-onebot` will be installed since peerDeps, hides new community plugin `koishi-plugin-adapter-onebot`)
systools: global side-effects (systoolsGlobals), poorly implemented auto update, poorly implemented event loop
systools-lts: global side-effects (systoolsGlobals), lovemilk-telemetry
lovemilk-telemetry: bad monkeypatch (hook on command private `_actions()` function)
